### PR TITLE
Add link to Github Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This is still work in progress.
 
 What I want to do is rebuild the scrum for developers presentation with reveal.js.
 
+Available at [Github Pages](https://scrum-for-developers.github.io/presentations/)
+
 ## Installation instructions
 
 To look at it, just open the index.html.


### PR DESCRIPTION
I wanted to show the slides to someone and I needed to enter the Github Pages URL manually. Now, it is not necessary anymore. 